### PR TITLE
Fix: adjacent_stations settings no longer exists

### DIFF
--- a/ext/xstation.nut
+++ b/ext/xstation.nut
@@ -68,7 +68,7 @@ class XStation
 				return id;
 			}
 		}
-		return Setting.Get(SetString.adjacent_stations) ? AIStation.STATION_JOIN_ADJACENT : AIStation.STATION_NEW;
+		return AIStation.STATION_JOIN_ADJACENT;
 	}
 
 	function IsInUse(id) {

--- a/utilities/enum.nut
+++ b/utilities/enum.nut
@@ -36,7 +36,6 @@ enum SetString {
 		nonuniform_stations = "station.nonuniform_stations"
 		station_spread = "station.station_spread"
 		modified_catchment = "station.modified_catchment"
-		adjacent_stations = "station.adjacent_stations"
 		distant_join_stations = "station.distant_join_stations"
 		infrastructure_maintenance = "economy.infrastructure_maintenance"
 }


### PR DESCRIPTION
Setting was removed in  https://github.com/OpenTTD/OpenTTD/commit/c3bb512bd95ecb9f0a69cc67682e302df2f2ced3

Since 15.0-beta1, TransAI was crashing because it was looking for it.