### PR TITLE
Fix: Crash when converting AIEventDisasterZeppelinerCleared event

### DIFF
--- a/task/events.nut
+++ b/task/events.nut
@@ -212,7 +212,7 @@ class Task.Events extends DailyTask
 					break;
 
 				case AIEvent.ET_DISASTER_ZEPPELINER_CLEARED:
-					item.push(AIEventDisasterZeppelinerCrashed.Convert(e).GetStationID());
+					item.push(AIEventDisasterZeppelinerCleared.Convert(e).GetStationID());
 					break;
 
 				case AIEvent.ET_DISASTER_ZEPPELINER_CRASHED:


### PR DESCRIPTION
Hi! I found a crash about this event. Here's the fix.

Btw, TransAI on bananas still using a version from 2019. Will you update it soon?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a crash when converting the Zeppeliner Cleared disaster event. The switch now uses ZeppelinerCleared.Convert(e) to get the station ID instead of ZeppelinerCrashed.Convert(e).

<sup>Written for commit bd466001036ff1e1637f017a945398f538fa572d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

