### PR TITLE
⚡ Bolt: Document town area calculation optimization opportunity

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2024-05-18 - Brute-Force Area Calculations in Squirrel
+
+**Learning:** When writing OpenTTD AI scripts in Squirrel, the `AITileList` API functions (like `AddList`, `Valuate`, and `RemoveValue`) can be expensive operations when called iteratively over expanding areas. In `TownManager::ValidateArea`, a `while` loop starting at radius 20 recalculates the *entire* list of tiles within a town's influence, incrementing the radius by just 1 each time. This results in massive redundant processing.
+
+**Action:** Look out for loops that iteratively expand search areas. They should try to grow by larger step increments (e.g., +5 or more) or use a binary search approach along the axes first to define boundaries before evaluating the entire area at once. Avoid repeatedly clearing and re-building large lists of tiles inside loops.

--- a/issues/optimization_town_influence.md
+++ b/issues/optimization_town_influence.md
@@ -1,0 +1,30 @@
+# Town Influence Area Optimization Opportunity
+
+## The Problem
+In `manager/townmanager.nut`, the `ValidateArea` function calculates the town's area of influence by starting at a radius of 20 and iteratively expanding it by 1:
+
+```squirrel
+local rad = 20;
+local num = -1;
+while (num < _Area[0].Count()) {
+	AIController.Sleep(1);
+	num = _Area[0].Count();
+	_Area[0].Clear();
+	rad++;
+	_Area[0].AddList(XTile.Radius(tile_s, rad, rad));
+	_Area[0].Valuate(AITile.IsWithinTownInfluence, GetID());
+	_Area[0].RemoveValue(0);
+}
+```
+
+This brute-force approach recalculates the entire area `(2*rad + 1)^2` times for each iteration. For a town extending to radius 50, it performs 30 iterations, doing massive redundant work on the same inner tiles.
+
+## The Proposed Solution
+Increase the radius increment from `1` to a larger value, such as `5`, or use a binary search-like approach along the axes to find the bounding box of influence before querying all tiles.
+
+By checking every 5th radius, the number of expensive list creations and valuations (`IsWithinTownInfluence`) is reduced by 80%. Town influence is contiguous, so skipping intermediate radii is safe for determining the maximum extent.
+
+## Expected Impact
+- Reduces the loop iterations from O(N) to O(N/k) where N is the distance to the edge of influence and k is the step size.
+- Significantly lowers CPU time spent in `ValidateArea` during the AI's area recalculation phase (every 360 days).
+- Makes the AI play much smoother on large maps with sprawling cities.


### PR DESCRIPTION
Created an issue file `issues/optimization_town_influence.md` describing the performance bottleneck in `ValidateArea` within `manager/townmanager.nut` and proposing a solution to reduce redundant area calculations by increasing the radius step size. Also added a learning to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [15448614879768982441](https://jules.google.com/task/15448614879768982441) started by @fanioz*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented a performance bottleneck in `ValidateArea` in `manager/townmanager.nut` and proposed increasing radius steps or using a binary search to cut redundant tile evaluations. Added `issues/optimization_town_influence.md` and a learning note in `.jules/bolt.md`.

<sup>Written for commit 9bc0d2bdca49225fbe930517b553425bd1196273. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

