### PR TITLE
fix: correct airport MakeLevel call and subsidy cargo comparison

### DIFF
--- a/ext/xairport.nut
+++ b/ext/xairport.nut
@@ -50,7 +50,7 @@ class XAirport
 			switch (AIError.GetLastError()) {
 				case AIError.ERR_AREA_NOT_CLEAR :
 				case AIError.ERR_FLAT_LAND_REQUIRED:
-					if (!XTile.MakeLevel(tile, x y)) return -1;;
+					if (!XTile.MakeLevel(tile, x, y)) return -1;
 					break;
 				case AIError.ERR_LOCAL_AUTHORITY_REFUSES:
 					if (!self.ImproveRating()) return -1;

--- a/utilities/service.nut
+++ b/utilities/service.nut
@@ -64,7 +64,7 @@ class Service
 
 	function GetSubsidyPrice(loc1, loc2, cargo) {
 		foreach(s_id, v in My._Subsidies) {
-			if (!AISubsidy.GetCargoType(s_id) == cargo) continue;
+			if (AISubsidy.GetCargoType(s_id) != cargo) continue;
 			if (!Service.IsSubsidyLocationWas(s_id, loc1, true)) continue;
 			if (!Service.IsSubsidyLocationWas(s_id, loc2, false)) continue;
 			My.Info("found a subsidy service for", XCargo.Label[cargo]);


### PR DESCRIPTION
## Summary

Phase 1 / Chunk 1 of the codebase-cleanup program — two latent bug fixes found during the Phase 0 audit (see `process/features/codebase-cleanup/references/audit-catalog.md`).

## Changes

### 1. `ext/xairport.nut` (BUG-02) — missing comma
```diff
- if (!XTile.MakeLevel(tile, x y)) return -1;;
+ if (!XTile.MakeLevel(tile, x, y)) return -1;
```
Missing comma between the `x` and `y` arguments, plus a stray double semicolon. This branch runs when airport construction fails with `ERR_AREA_NOT_CLEAR` or `ERR_FLAT_LAND_REQUIRED` and the AI attempts to terraform the tile.

### 2. `utilities/service.nut` (BUG-07) — operator precedence
```diff
- if (!AISubsidy.GetCargoType(s_id) == cargo) continue;
+ if (AISubsidy.GetCargoType(s_id) != cargo) continue;
```
`!x == cargo` was parsed as `(!x) == cargo`. Since `GetCargoType` returns a non-zero integer cargo ID, `!id` evaluates to `false`, so the comparison almost never matched — subsidy price multipliers were effectively never applied.

## ⚠️ Behavioral impact

**BUG-07 is a behavior change.** Subsidized routes will now correctly receive the price multiplier in `GetSubsidyPrice`. This is the *intended* fix, but it may slightly change the AI's route-selection behavior (subsidized cargoes become more attractive than before). Worth watching in-game after merge.

## Test plan

- [ ] Reviewers confirm the `!= cargo` fix matches original intent (subsidies should match by cargo type)
- [ ] **Runtime check (manual):** load Trans AI in OpenTTD, confirm airports still build on rough terrain (exercises BUG-02 fix path), and confirm subsidized routes get priority (exercises BUG-07 fix)
- [ ] No automated test harness exists for this Squirrel codebase — verification is manual

## Program context

- Phase plan: `process/features/codebase-cleanup/active/phase-1-ext-simplify_PLAN_13-06-26.md`
- Audit catalog: `process/features/codebase-cleanup/references/audit-catalog.md` (BUG-02, BUG-07)
- Part of the codebase-cleanup phase program (DRY/KISS/cleanup). This is chunk 1 of 4 for Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected airport construction logic to properly attempt terrain leveling when suitable flat land is unavailable
  * Fixed cargo type matching in subsidy pricing calculations to ensure accurate service price determination

<!-- end of auto-generated comment: release notes by coderabbit.ai -->